### PR TITLE
bumped pytorch version to new requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -23,7 +23,7 @@ requirements:
     - opt_einsum >=2.3.2
     - pyro-api >=0.1.1
     - python >=3.6
-    - pytorch >=1.8
+    - pytorch >=1.9
     - tqdm >=4.36
 
 test:


### PR DESCRIPTION

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

pyro-ppl 1.7 requires pytorch 1.9. The previous auto-bump PR didn't notice, but pytorch 1.9 wasn't available on conda-forge until now. Since it was available from the `pytorch` channel I figured I'd let it be until I could update the requirement.